### PR TITLE
Use env Google API key for VueGoogleMaps and remove dev console log

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,13 +13,10 @@ app.use(pinia)
 app.use(router)
 
 const key = import.meta.env.VITE_GOOGLE_API_KEY
-if (import.meta.env.DEV) {
-  console.log('✅ 実際のAPIキー:', key)
-}
 
 app.use(VueGoogleMaps, {
   load: {
-    key: 'AIzaSyDiNJLDZz_STC2tqG-14imShfnkPGgcKp4',
+    key,
     libraries: 'places',
     v: 'weekly',
     loading: 'async',


### PR DESCRIPTION
### Motivation
- Replace a hardcoded Google Maps API key with the environment-provided `VITE_GOOGLE_API_KEY` and remove a dev-only console log to avoid exposing keys in logs.

### Description
- Switched the `VueGoogleMaps` `load.key` from a hardcoded string to the `key` read from `import.meta.env.VITE_GOOGLE_API_KEY`.
- Removed a development-only `console.log` that printed the API key.
- Kept CSRF cookie fetch before mounting the app unchanged.

### Testing
- Ran the existing automated test suite (`npm test`) and CI build (application build) which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fc42d3a48330a45c6c63bec52c8e)