### PR TITLE
[codex] チェックイン完了メッセージに店舗名を表示

### DIFF
--- a/src/utils/shop.test.ts
+++ b/src/utils/shop.test.ts
@@ -1,6 +1,6 @@
 // src/utils/shop.test.ts
 import { describe, it, expect } from 'vitest'
-import { extractPrefecture, getDistance } from './shop'
+import { extractPrefecture, formatVisitSuccessMessage, getDistance } from './shop'
 
 describe('extractPrefecture', () => {
   it('住所から都道府県名を抽出できる', () => {
@@ -24,5 +24,19 @@ describe('getDistance', () => {
     const b = getDistance(35.710063, 139.8107, 35.681236, 139.767125)
     expect(a).toBeGreaterThan(0)
     expect(Math.abs(a - b)).toBeLessThan(1e-6 * a)
+  })
+})
+
+describe('formatVisitSuccessMessage', () => {
+  it('店舗名を含むチェックイン完了メッセージを返す', () => {
+    expect(formatVisitSuccessMessage('ゲームセンター東京', 'チェックインが完了しました')).toBe(
+      'ゲームセンター東京\nにチェックインが完了しました',
+    )
+  })
+
+  it('店舗名が空の場合はAPIメッセージだけを返す', () => {
+    expect(formatVisitSuccessMessage('', 'チェックインが完了しました')).toBe(
+      'チェックインが完了しました',
+    )
   })
 })

--- a/src/utils/shop.ts
+++ b/src/utils/shop.ts
@@ -14,3 +14,12 @@ export const getDistance = (lat1: number, lon1: number, lat2: number, lon2: numb
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
   return R * c
 }
+
+export const formatVisitSuccessMessage = (
+  shopName: string | undefined,
+  message = 'チェックインが完了しました',
+): string => {
+  const trimmedShopName = shopName?.trim()
+
+  return trimmedShopName ? `${trimmedShopName}\nに${message}` : message
+}

--- a/src/views/Shops.vue
+++ b/src/views/Shops.vue
@@ -62,6 +62,7 @@
   import AdNinja from '@/components/common/AdNinja.vue'
   import {
     extractPrefecture,
+    formatVisitSuccessMessage,
     getDistance,
   } from '@/utils/shop'
     import type { Shop } from '@/types'
@@ -185,7 +186,9 @@
   async function recordVisit(shopId: number) {
   try {
     const res = await api.post('/api/visit', { shop_id: shopId })
-    alert(res.data.message || '✅ 行脚しました！')
+    const shopName = shops.value.find((shop) => shop.id === shopId)?.name
+    const message = res.data.message || 'チェックインが完了しました'
+    alert(formatVisitSuccessMessage(shopName, message))
 
     if (!visitedShopIds.value.includes(shopId)) {
       visitedShopIds.value.push(shopId)


### PR DESCRIPTION
## 概要
- チェックイン成功時のメッセージに対象店舗名を追加しました
- API から返る成功メッセージを利用しつつ、店舗名が取得できる場合は先頭行に表示します
- メッセージ整形処理を `shop` utility に切り出し、ユニットテストを追加しました

## 確認
- `npm test -- --run src/utils/shop.test.ts`
- `npm run build`

Closes #35