### PR TITLE
[codex] スマホの店舗地図を全画面表示できるようにする

### DIFF
--- a/src/components/shop/ShopMap.vue
+++ b/src/components/shop/ShopMap.vue
@@ -1,24 +1,23 @@
 <template>
   <section
     id="map"
-    class="card"
-    style="max-width: 1000px; position: relative;"
+    class="map-container card"
+    :class="{ 'is-fullscreen': isFullscreen }"
   >
-    <!-- ✅ スマホのみ表示される全画面ボタン -->
     <button
-      v-if="isMobile && !showOverlayMap"
-      @click="showOverlayMap = true"
+      type="button"
       class="fullscreen-btn"
+      :aria-label="isFullscreen ? '地図の全画面表示を終了' : '地図を全画面表示'"
+      @click="toggleFullscreen"
     >
-      地図を全画面で見る
+      {{ isFullscreen ? '✕ 閉じる' : '地図を全画面で見る' }}
     </button>
 
-    <!-- ✅ 通常地図 -->
     <GMapMap
       :center="center"
       :api-key="GOOGLE_MAP_API_KEY"
       :zoom="11"
-      style="width: 100%; height: 600px"
+      class="shop-map"
       @bounds_changed="$emit('map-ready')"
       :options="mapOptions"
     >
@@ -50,48 +49,11 @@
 
     <!-- ✅ 現在地ボタン -->
     <button @click="$emit('move-center')" class="locate-btn">📍 現在地</button>
-
-    <!-- ✅ 全画面オーバーレイ地図 -->
-    <div v-if="showOverlayMap" class="overlay-map">
-      <button @click="showOverlayMap = false" class="close-btn">✕</button>
-
-      <GMapMap
-        :center="center"
-        :api-key="GOOGLE_MAP_API_KEY"
-        :zoom="11"
-        style="width: 100vw; height: 100vh"
-        @bounds_changed="$emit('map-ready')"
-        :options="mapOptions"
-      >
-        <GMapMarker
-          v-if="userLocation && currentLocationIcon"
-          :position="userLocation"
-          :icon="currentLocationIcon"
-        />
-
-        <GMapMarker
-          v-for="shop in shops"
-          :key="shop.id"
-          :position="{ lat: Number(shop.lat), lng: Number(shop.lng) }"
-          :icon="getMarkerIcon(shop.id)"
-          @click="$emit('marker-click', shop)"
-        >
-          <template v-if="shop.isOpen">
-            <ShopInfoWindow
-              :shop="shop"
-              :isNear="isNear(shop)"
-              @close="shop.isOpen = false"
-              @record="onRecordVisit(shop.id)"
-            />
-          </template>
-        </GMapMarker>
-      </GMapMap>
-    </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import type { Shop } from '@/types'
 import ShopInfoWindow from './ShopInfoWindow.vue'
 
@@ -113,17 +75,8 @@ const emit = defineEmits<{
   (e: 'map-ready'): void
 }>()
 
-const showOverlayMap = ref(false)
-const isMobile = ref(false)
-
-onMounted(() => {
-  const checkMobile = () => {
-    isMobile.value = window.matchMedia('(max-width: 768px)').matches
-  }
-
-  checkMobile()
-  window.addEventListener('resize', checkMobile)
-})
+const isFullscreen = ref(false)
+let previousBodyOverflow = ''
 
 const mapOptions = {
   fullscreenControl: true,
@@ -131,6 +84,26 @@ const mapOptions = {
   mapTypeControl: false,
   streetViewControl: false,
   gestureHandling: 'greedy',
+}
+
+watch(isFullscreen, async (fullscreen) => {
+  if (fullscreen) {
+    previousBodyOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  } else {
+    document.body.style.overflow = previousBodyOverflow
+  }
+
+  await nextTick()
+  window.dispatchEvent(new Event('resize'))
+})
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = previousBodyOverflow
+})
+
+function toggleFullscreen() {
+  isFullscreen.value = !isFullscreen.value
 }
 
 function onRecordVisit(shopId: number) {
@@ -145,6 +118,30 @@ function getMarkerIcon(shopId: number): string {
 </script>
 
 <style scoped>
+.map-container {
+  position: relative;
+  width: 100%;
+  max-width: 1000px;
+}
+
+.map-container.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 20000;
+  max-width: none;
+  background: white;
+}
+
+.shop-map {
+  width: 100%;
+  height: 600px;
+}
+
+.is-fullscreen .shop-map {
+  height: 100vh;
+  height: 100dvh;
+}
+
 .locate-btn {
   position: absolute;
   bottom: 50px;
@@ -159,35 +156,29 @@ function getMarkerIcon(shopId: number): string {
 }
 
 .fullscreen-btn {
+  display: none;
   position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 10000;
+  top: calc(env(safe-area-inset-top) + 10px);
+  right: calc(env(safe-area-inset-right) + 10px);
+  z-index: 20;
   background: #333;
   color: white;
   padding: 6px 10px;
   border-radius: 4px;
   font-size: 0.9rem;
   border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-.overlay-map {
-  position: fixed;
-  inset: 0;
-  background: white;
-  z-index: 9999;
-}
+@media (hover: none), (max-width: 768px) {
+  .fullscreen-btn {
+    display: block;
+  }
 
-.close-btn {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 10000;
-  background: #333;
-  color: white;
-  padding: 8px 12px;
-  border-radius: 4px;
-  font-size: 1rem;
-  border: none;
+  .locate-btn {
+    bottom: calc(env(safe-area-inset-bottom) + 50px);
+    right: calc(env(safe-area-inset-right) + 10px);
+  }
 }
 </style>


### PR DESCRIPTION
## 概要

スマホ版の店舗地図で Google Maps 標準の全画面ボタンが表示されない問題に対応しました。

Closes #9

## 変更内容

- スマホ・タッチ端末向けの全画面切替ボタンを常時表示
- 通常表示用と全画面用で地図を二重生成していた実装を、単一の地図コンテナを全画面化する方式へ変更
- 全画面表示中の背景スクロールを固定し、終了時とアンマウント時に復元
- `100dvh` と safe area を使用し、モバイルブラウザの表示領域やノッチを考慮
- 全画面切替後に resize イベントを発火し、Google Maps の描画領域を更新

## 原因

Google Maps JavaScript API の標準全画面コントロールはモバイル環境で表示されない場合があります。既存の代替実装は地図を別インスタンスとして再生成していたため、状態の重複や背景スクロールの問題が残っていました。

## 確認

- `npm run build`
- `npm test -- --run`（14件成功）
- 390 x 844 のスマホ相当 viewport で全画面表示・終了を確認
- 全画面時に地図が viewport 全体へ広がることを確認
- 終了時に元のサイズと背景スクロール状態へ戻ることを確認