### PR TITLE
[codex] Fix title typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=960" />
-    <title>REFLEC BEAT plus レベル11 難易度表＆クリアランク管理サイトr</title>
+    <title>REFLEC BEAT plus レベル11 難易度表＆クリアランク管理サイト</title>
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>


### PR DESCRIPTION
## 概要

`index.html`の`title`タグ末尾に誤って含まれていた`r`を削除しました。

## 原因

2026年6月6日のタイトル更新時に、末尾へ`r`が混入していました。この文字列がそのまま本番サイトのブラウザタイトルに表示されていました。

## 影響

ブラウザのタブや検索結果などに表示されるサイトタイトルが、意図した「REFLEC BEAT plus レベル11 難易度表＆クリアランク管理サイト」になります。

## 確認

- `npm run build`
- `git diff --check`
- 生成された`dist/index.html`の`title`を確認