### PR TITLE
[codex] Hide check-in button for visited shops

### DIFF
--- a/src/components/shop/ShopInfoWindow.vue
+++ b/src/components/shop/ShopInfoWindow.vue
@@ -5,7 +5,7 @@
       📍 {{ shop.address }}<br />
       🎮 {{ shop.price }}円 / 🕹️ {{ shop.number_of_machine }}台<br />
       {{ shop.description }}<br />
-      <div v-if="isNear && isLoggedIn" style="margin-top: 10px;">
+      <div v-if="isNear && isLoggedIn && !isVisited" style="margin-top: 10px;">
         <button @click="$emit('record')">✅ この店舗に行脚記録をつける</button>
       </div>
     </div>
@@ -22,6 +22,7 @@ const isLoggedIn = !!authStore.user
 defineProps<{
   shop: Shop
   isNear: boolean
+  isVisited: boolean
 }>()
 
 defineEmits<{

--- a/src/components/shop/ShopMap.vue
+++ b/src/components/shop/ShopMap.vue
@@ -40,6 +40,7 @@
           <ShopInfoWindow
             :shop="shop"
             :isNear="isNear(shop)"
+            :isVisited="isVisited(shop.id)"
             @close="shop.isOpen = false"
             @record="onRecordVisit(shop.id)"
           />
@@ -110,8 +111,12 @@ function onRecordVisit(shopId: number) {
   emit('record-visit', shopId)
 }
 
-function getMarkerIcon(shopId: number): string {
+function isVisited(shopId: number): boolean {
   return props.visitedShopIds.includes(shopId)
+}
+
+function getMarkerIcon(shopId: number): string {
+  return isVisited(shopId)
     ? 'https://maps.google.com/mapfiles/ms/icons/green-dot.png'
     : 'https://maps.google.com/mapfiles/ms/icons/red-dot.png'
 }


### PR DESCRIPTION
## Summary
- Pass visited-shop state from `ShopMap` into `ShopInfoWindow`
- Hide the check-in button when the selected shop has already been visited
- Reuse the same visited-state helper for marker color and info-window rendering

## Root Cause
`ShopInfoWindow` only checked whether the user was nearby and logged in, so already visited shops still showed the check-in button.

## Validation
- `npm run build`
- `npm test -- --run`

Closes #49